### PR TITLE
Support multi-line in request fields

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -25,7 +25,7 @@ echo "Calling bitbucket create PR API..."
 response=$(curl --location --request POST "${GIT_BASE_URL}/rest/api/1.0/projects/${GIT_PROJECT}/repos/${GIT_REPO}/pull-requests" \
 --header "Authorization: Bearer ${GIT_ACCESS_TOKEN}" \
 --header 'Content-Type: application/json' \
---data-raw "{
+--data-binary "{
     \"title\": \"${PR_TITLE}\",
     \"description\": \"${PR_DESCRIPTION}\",
     \"state\": \"OPEN\",


### PR DESCRIPTION
To create a pull request whose description contains multiple lines, we need to send the corresponding `description` entry in our JSON request body. 
However, since JSON does not support line breaks in entires, we need to escape those line breaks into `\n` characters. Then when BitBucket parses the JSON request, it will understand that it represents a new line character. 
The problem is, once we do that, then curl will attempt to encode that again into `\\n`. That would cause BitBucket to decode it into `\n` again, and that `\n` character will appear in the description of our created pull requests. 

Changing the option `data-raw` with `data-binary` tells curl to 
> post data exactly as specified with no extra processing whatsoever.

So that a `\n` is sent as `\n` verbatim, no processing applied. 